### PR TITLE
Add I2C-6 lm75 outlet temperature sensor

### DIFF
--- a/bin/Barreleye.py
+++ b/bin/Barreleye.py
@@ -620,6 +620,11 @@ HWMON_CONFIG = {
                         'in14_input' : { 'object_path' : 'voltage/P1V35_CPU1_BUF3','poll_interval' : 10000,'scale' : 1,'units' : '' },
 		}
          },
+	'6-0048' : {
+		'names' : {
+                        'temp1_input' : { 'object_path' : 'temperature/outlet','poll_interval' : 5000,'scale' : 1000,'units' : 'C' },
+		}
+	},
 	'3-0050' : {
 		'names' : {
 			'caps_curr_powercap' : { 'object_path' : 'powercap/curr_cap','poll_interval' : 10000,'scale' : 1,'units' : 'W' },

--- a/objects/hwmons_barreleye.c
+++ b/objects/hwmons_barreleye.c
@@ -20,18 +20,19 @@ typedef struct {
   int fd;
 } HWMON;
 
-#define  NUM_HWMONS 7
+#define  NUM_HWMONS 8
 
 // TODO: Don't hardcode
 //Hardcoded for barreleye
 HWMON hwmons[NUM_HWMONS] = { 
 	(HWMON){"/sys/class/hwmon/hwmon0/temp1_input","temperature/ambient",3000,"C",1000},
-	(HWMON){"/sys/class/hwmon/hwmon1/pwm1","speed/fan0",30000,"",1},
-	(HWMON){"/sys/class/hwmon/hwmon1/pwm2","speed/fan1",30000,"",1},
-	(HWMON){"/sys/class/hwmon/hwmon1/pwm3","speed/fan2",30000,"",1},
-	(HWMON){"/sys/class/hwmon/hwmon2/pwm1","speed/fan3",30000,"",1},
-	(HWMON){"/sys/class/hwmon/hwmon2/pwm2","speed/fan4",30000,"",1},
-	(HWMON){"/sys/class/hwmon/hwmon2/pwm3","speed/fan5",30000,"",1},
+	(HWMON){"/sys/class/hwmon/hwmon1/temp1_input","temperature/outlet",5000,"C",1000},
+	(HWMON){"/sys/class/hwmon/hwmon2/pwm1","speed/fan0",30000,"",1},
+	(HWMON){"/sys/class/hwmon/hwmon2/pwm2","speed/fan1",30000,"",1},
+	(HWMON){"/sys/class/hwmon/hwmon2/pwm3","speed/fan2",30000,"",1},
+	(HWMON){"/sys/class/hwmon/hwmon3/pwm1","speed/fan3",30000,"",1},
+	(HWMON){"/sys/class/hwmon/hwmon3/pwm2","speed/fan4",30000,"",1},
+	(HWMON){"/sys/class/hwmon/hwmon3/pwm3","speed/fan5",30000,"",1},
 };
 bool is_hwmon_valid(HWMON* hwmon)
 {


### PR DESCRIPTION
Add lm75 outlet temperature sensor on I2C-6 for Barreleye

We can explicitly call this sensor without instantiating from
device tree by:
`echo lm75 0x48 > /sys/bus/i2c/devices/i2c-6/new_device`
