### PR TITLE
Modify the hard-coded hwmon ID for PowerCap

### DIFF
--- a/bin/Sensors.py
+++ b/bin/Sensors.py
@@ -137,7 +137,7 @@ class PowerCap(VirtualSensor):
 	def __init__(self, bus, name):
 		VirtualSensor.__init__(self, bus, name)
 		SensorValue.setValue(self, 0)
-		self.sysfs_attr = "/sys/class/hwmon/hwmon3/user_powercap"
+		self.sysfs_attr = "/sys/class/hwmon/hwmon4/user_powercap"
 	##override setValue method
 	@dbus.service.method(SensorValue.IFACE_NAME,
 		in_signature='v', out_signature='')

--- a/bin/sensor_manager2.py
+++ b/bin/sensor_manager2.py
@@ -54,9 +54,9 @@ if __name__ == '__main__':
 
 	obj_path = OBJ_PATH+"/host/PowerCap"
 	sensor_obj = Sensors.PowerCap(bus,obj_path)
-	## hwmon3 is default for master OCC on Barreleye.
+	## hwmon4 is default for master OCC on Barreleye.
 	## should rewrite sensor_manager to remove hardcode
-	sensor_obj.sysfs_attr = "/sys/class/hwmon/hwmon3/user_powercap"
+	sensor_obj.sysfs_attr = "/sys/class/hwmon/hwmon4/user_powercap"
 	root_sensor.add(obj_path,sensor_obj)
 
 	obj_path = OBJ_PATH+"/host/BootProgress"


### PR DESCRIPTION
After we enable I2C-6 lm75 outlet sensor in device stree, the hwmon ID
of PowerCap won't be 3 anymore. So we have to modify it as real ID.
