### PR TITLE
configs/Barreleye.py: Turn off the Beep LED after BMC is ready

### DIFF
--- a/configs/Barreleye.py
+++ b/configs/Barreleye.py
@@ -64,6 +64,11 @@ ENTER_STATE_CALLBACK = {
 
 	},
 	'BMC_READY' : {
+		'setOff' : {
+			'bus_name'   : 'org.openbmc.control.led',
+			'obj_name'   : '/org/openbmc/control/led/beep',
+			'interface_name' : 'org.openbmc.Led',
+		},
 		'setBlinkSlow' : {
 			'bus_name'   : 'org.openbmc.control.led',
 			'obj_name'   : '/org/openbmc/control/led/heartbeat',


### PR DESCRIPTION
Considering the commit 8477f1f72a7bdd68b487085a9df41b815b24cbcc, the LED will keep the power-on reset state.
The Beep LED keeps as ON on Barreleye after merge that commit, so we have to turn off
it base on the Barreleye HW spec.
- LED consistently on when BMC code is initialing
- LED consistently off when BMC is ready

Signed-off-by: johnhcwang hsienchiang@gmail.com
