### PR TITLE
discover_system_state: Restore the power with the random delay

### DIFF
--- a/configs/Barreleye.py
+++ b/configs/Barreleye.py
@@ -230,6 +230,7 @@ APPS = {
 		'start_process'   : True,
 		'monitor_process' : False,
 		'process_name'    : 'discover_system_state.py',
+		'args'            : ['--rand','10'],
 	},
 	'bmc_control' : {
 		'system_state'    : 'BMC_STARTING',

--- a/pystatemgr/discover_system_state.py
+++ b/pystatemgr/discover_system_state.py
@@ -5,7 +5,8 @@ import gobject
 import dbus
 import dbus.service
 import dbus.mainloop.glib
-
+import random
+import time
 
 dbus_objects = {
 	'power' : { 
@@ -71,6 +72,10 @@ else:
 	if (power_policy == "ALWAYS_POWER_ON" or
 	   (power_policy == "RESTORE_LAST_STATE" and 
 	    system_state =="HOST_POWERED_ON")):
+		if (len(sys.argv) >= 3 and sys.argv[1] == '--rand' and int(sys.argv[2]) > 0):
+			delay_time = random.randrange(0,int(sys.argv[2]))
+			print "Random power on after "+str(delay_time)+" seconds"
+			time.sleep(delay_time)
 		chassis_intf.powerOn()
 
 


### PR DESCRIPTION
Consider the inrush current while a lot of nodes power on at the same time in data
center, so implement the random power on mechanism to avoid such situation.

Signed-off-by: johnhcwang hsienchiang@gmail.com
